### PR TITLE
Update dockerfile

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -27,7 +27,8 @@ RUN pip install -r requirements.txt
 
 
 COPY frontend/package.json frontend/package.json
-RUN cd frontend && npm install
+COPY frontend/package-lock.json frontend/package-lock.json
+RUN cd frontend && npm ci
 COPY frontend frontend
 RUN cd frontend && npm run build
 


### PR DESCRIPTION
o `npm install` atualiza as dependencias do package-lock pra ultima versão, pra não ter esse risco, existe o `npm ci` que instala as versões pinadas.